### PR TITLE
Migrate aws_c_{common, http, io, mqtt} & s2n

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.8.____73_pypy.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.8.____73_pypy.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.8.* *_73_pypy
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.9.____73_pypy.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_64_python3.9.____73_pypy.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_73_pypy
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-64

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-64

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_aarch64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -39,6 +39,6 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -39,6 +39,6 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_aarch64_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____73_pypy.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_aarch64_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____73_pypy.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -39,6 +39,6 @@ pin_run_as_build:
 python:
 - 3.8.* *_73_pypy
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -39,6 +39,6 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_aarch64_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____73_pypy.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_aarch64_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____73_pypy.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -39,6 +39,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_73_pypy
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -39,6 +39,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-aarch64

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.10.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-ppc64le

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.11.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-ppc64le

--- a/.ci_support/linux_ppc64le_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____73_pypy.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_ppc64le_python3.8.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____73_pypy.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.8.* *_73_pypy
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-ppc64le

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.8.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-ppc64le

--- a/.ci_support/linux_ppc64le_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____73_pypy.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_ppc64le_python3.9.____73_pypy.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____73_pypy.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_73_pypy
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-ppc64le

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.9.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:
@@ -35,6 +35,6 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 s2n:
-- 1.3.31
+- 1.3.33
 target_platform:
 - linux-ppc64le

--- a/.ci_support/migrations/aws_c_common089.yaml
+++ b/.ci_support/migrations/aws_c_common089.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_common:
+- 0.8.9
+migrator_ts: 1673680911.2455108

--- a/.ci_support/migrations/aws_c_http073.yaml
+++ b/.ci_support/migrations/aws_c_http073.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  automerge: true
+aws_c_http:
+- 0.7.3
+migrator_ts: 1675172490.116017

--- a/.ci_support/migrations/aws_c_io01314.yaml
+++ b/.ci_support/migrations/aws_c_io01314.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+aws_c_io:
+- 0.13.14
+migrator_ts: 1673680924.2678478

--- a/.ci_support/migrations/aws_c_mqtt086.yaml
+++ b/.ci_support/migrations/aws_c_mqtt086.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  use_local: true
+aws_c_mqtt:
+- 0.8.6
+migrator_ts: 1675298787.1496816

--- a/.ci_support/migrations/s2n1333.yaml
+++ b/.ci_support/migrations/s2n1333.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+migrator_ts: 1674120201.4427557
+s2n:
+- 1.3.33

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.8.____73_pypy.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.8.____73_pypy.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.9.____73_pypy.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/osx_64_python3.9.____73_pypy.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -5,13 +5,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.10.____cpython.yaml
+++ b/.ci_support/win_64_python3.10.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/win_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/win_64_python3.8.____73_pypy.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.8.____73_pypy.yaml
+++ b/.ci_support/win_64_python3.8.____73_pypy.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/win_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/win_64_python3.9.____73_pypy.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.9.____73_pypy.yaml
+++ b/.ci_support/win_64_python3.9.____73_pypy.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -11,7 +11,7 @@ aws_c_http:
 aws_c_io:
 - 0.13.14
 aws_c_mqtt:
-- 0.7.13
+- 0.8.6
 aws_c_s3:
 - 0.2.3
 aws_checksums:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -3,13 +3,13 @@ aws_c_auth:
 aws_c_cal:
 - 0.5.20
 aws_c_common:
-- 0.8.5
+- 0.8.9
 aws_c_event_stream:
 - 0.2.18
 aws_c_http:
-- 0.7.0
+- 0.7.3
 aws_c_io:
-- 0.13.12
+- 0.13.14
 aws_c_mqtt:
 - 0.7.13
 aws_c_s3:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-Don-t-force-static-linkage.patch
 
 build:
-  number: 23
+  number: 24
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,12 @@
-{% set name = "awscrt" %}
 {% set version = "0.15.3" %}
 
 
 package:
-  name: {{ name|lower }}
+  name: awscrt
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/awscrt-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/a/awscrt/awscrt-{{ version }}.tar.gz
   sha256: 8c76db33f2f3285d8cde3183d0f3f3c731e9066e1bd609d6337620a5d82095a5
   patches:
     - 0001-Don-t-force-static-linkage.patch


### PR DESCRIPTION
Migrators racing + being pinned to old versions not being ABI-migrated anymore in other parts of the aws-* stack = conflict

(also, I realised the migrators will not be able to get unstuck by themselves even after fixing individual feedstocks, because they depend on each other for _every_ feedstock)